### PR TITLE
Updated Haddop to version 3.2.3 since 3.2.1 is no longer available

### DIFF
--- a/notebooks/1.HadoopDocker.ipynb
+++ b/notebooks/1.HadoopDocker.ipynb
@@ -78,16 +78,17 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Install Hadoop\n",
     "\n",
     "- http://hadoop.apache.org/\n",
-    "- Version 3.2.1\n",
+    "- Version 3.2.3\n",
     "- Base directory: /opt\n",
     "- User/group: hadoop/hadoop\n",
-    "- Package with binaries (version 3.2.1): https://hadoop.apache.org/releases.html"
+    "- Package with binaries (version 3.2.3): https://hadoop.apache.org/releases.html"
    ]
   },
   {
@@ -116,7 +117,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "HADOOPVERSION=hadoop-3.2.2\n",
+    "HADOOPVERSION=hadoop-3.2.3\n",
     "\n",
     "# Download package\n",
     "cd ../pkgs\n",
@@ -134,7 +135,7 @@
    "source": [
     "%%dockerexec -u hadoop hadoopimg\n",
     "\n",
-    "HADOOPVERSION=hadoop-3.2.2\n",
+    "HADOOPVERSION=hadoop-3.2.3\n",
     "\n",
     "# Modify user/group permissions and unpack file\n",
     "sudo chown hadoop:hadoop /opt/$HADOOPVERSION.tar.gz\n",
@@ -241,13 +242,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### core-site.xml\n",
     "\n",
     "- Hadoop main configuration\n",
-    "- Default parameters: http://hadoop.apache.org/docs/r3.2.1/hadoop-project-dist/hadoop-common/core-default.xml"
+    "- Default parameters: http://hadoop.apache.org/docs/r3.2.3/hadoop-project-dist/hadoop-common/core-default.xml"
    ]
   },
   {
@@ -283,13 +285,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### hdfs-site.xml\n",
     "\n",
     "- HDFS configuration\n",
-    "- Default parameters: http://hadoop.apache.org/docs/r3.2.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml"
+    "- Default parameters: http://hadoop.apache.org/docs/r3.2.3/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml"
    ]
   },
   {
@@ -341,13 +344,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### yarn-site.xml\n",
     "\n",
     "- YARN configuration\n",
-    "- Default parameters: http://hadoop.apache.org/docs/r3.2.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml"
+    "- Default parameters: http://hadoop.apache.org/docs/r3.2.3/hadoop-yarn/hadoop-yarn-common/yarn-default.xml"
    ]
   },
   {
@@ -417,13 +421,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### mapred-site.xml\n",
     "\n",
     "- MapReduce configuration\n",
-    "- Default parameters: http://hadoop.apache.org/docs/r3.2.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml"
+    "- Default parameters: http://hadoop.apache.org/docs/r3.2.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml"
    ]
   },
   {
@@ -809,7 +814,7 @@
     "source /opt/envvars.sh\n",
     "cd /opt/hadoop/share/hadoop/mapreduce\n",
     "\n",
-    "hadoop jar ./hadoop-mapreduce-examples-3.2.2.jar pi 6 10000"
+    "hadoop jar ./hadoop-mapreduce-examples-3.2.3.jar pi 6 10000"
    ]
   },
   {

--- a/notebooks/2.YARN.ipynb
+++ b/notebooks/2.YARN.ipynb
@@ -40,13 +40,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Hadoop MapReduce Examples\n",
     "\n",
     "```\n",
-    "$HADOOP_HOME/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.2.1.jar\n",
+    "$HADOOP_HOME/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.2.3.jar\n",
     "```\n",
     "\n",
     "- aggregatewordcount: An Aggregate based map/reduce program that counts the words in the input files.\n",
@@ -83,11 +84,11 @@
     "\n",
     "cd /opt/hadoop/share/hadoop/mapreduce\n",
     "\n",
-    "# hadoop jar ./hadoop-mapreduce-examples-3.2.2.jar\n",
+    "# hadoop jar ./hadoop-mapreduce-examples-3.2.3.jar\n",
     "\n",
     "# randomwriter: A map/reduce program that writes 10GB of random data per node\n",
     "# configured for 150MB of random text / 50 MB per map (3 maps)\n",
-    "hadoop jar ./hadoop-mapreduce-examples-3.2.2.jar randomtextwriter \\\n",
+    "hadoop jar ./hadoop-mapreduce-examples-3.2.3.jar randomtextwriter \\\n",
     "  -D mapreduce.randomtextwriter.totalbytes=157286400 \\\n",
     "  -D mapreduce.randomtextwriter.bytespermap=52428800 \\\n",
     "  -D mapreduce.output.fileoutputformat.compress=false \\\n",
@@ -95,7 +96,7 @@
     "  randomtext\n",
     "\n",
     "# wordcount: A map/reduce program that counts the words in the input files\n",
-    "hadoop jar ./hadoop-mapreduce-examples-3.2.2.jar wordcount randomtext randomtextcount\n",
+    "hadoop jar ./hadoop-mapreduce-examples-3.2.3.jar wordcount randomtext randomtextcount\n",
     "\n"
    ]
   },
@@ -110,22 +111,23 @@
     "cd /opt/hadoop/share/hadoop/mapreduce\n",
     "\n",
     "# Teragen - 200MB\n",
-    "hadoop jar ./hadoop-mapreduce-examples-3.2.2.jar teragen \\\n",
+    "hadoop jar ./hadoop-mapreduce-examples-3.2.3.jar teragen \\\n",
     "  2000000 \\\n",
     "  teragenoutput\n",
     "\n",
     "# Terasort\n",
-    "hadoop jar ./hadoop-mapreduce-examples-3.2.2.jar terasort \\\n",
+    "hadoop jar ./hadoop-mapreduce-examples-3.2.3.jar terasort \\\n",
     "  teragenoutput terasortoutput"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## YARN - CLI\n",
     "\n",
-    "- https://hadoop.apache.org/docs/r3.2.1/hadoop-yarn/hadoop-yarn-site/YarnCommands.html"
+    "- https://hadoop.apache.org/docs/r3.2.3/hadoop-yarn/hadoop-yarn-site/YarnCommands.html"
    ]
   },
   {

--- a/notebooks/3.HDFS.ipynb
+++ b/notebooks/3.HDFS.ipynb
@@ -65,10 +65,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- https://hadoop.apache.org/docs/r3.2.1/hadoop-project-dist/hadoop-common/FileSystemShell.html\n",
+    "- https://hadoop.apache.org/docs/r3.2.3/hadoop-project-dist/hadoop-common/FileSystemShell.html\n",
     "\n",
     "Download books from Gutenberg project (http://www.gutenberg.org/)\n",
     "\n",
@@ -184,7 +185,7 @@
     "cd /opt/hadoop/share/hadoop/mapreduce\n",
     "\n",
     "# run wordcount application\n",
-    "hadoop jar ./hadoop-mapreduce-examples-3.2.2.jar wordcount \\\n",
+    "hadoop jar ./hadoop-mapreduce-examples-3.2.3.jar wordcount \\\n",
     "/user/hadoop/gutenberg /user/hadoop/gutenberg-output"
    ]
   },
@@ -250,7 +251,7 @@
     "cd /opt/hadoop/share/hadoop/mapreduce\n",
     "\n",
     "# run wordcount application with 2 reducers\n",
-    "hadoop jar ./hadoop-mapreduce-examples-3.2.2.jar wordcount \\\n",
+    "hadoop jar ./hadoop-mapreduce-examples-3.2.3.jar wordcount \\\n",
     "-Dmapreduce.job.reduces=2 \\\n",
     "/user/hadoop/gutenberg /user/hadoop/gutenberg-output"
    ]
@@ -285,12 +286,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Advanced Commands\n",
     "\n",
-    "- https://hadoop.apache.org/docs/r3.2.1/hadoop-project-dist/hadoop-hdfs/HDFSCommands.html"
+    "- https://hadoop.apache.org/docs/r3.2.3/hadoop-project-dist/hadoop-hdfs/HDFSCommands.html"
    ]
   },
   {
@@ -509,7 +511,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -523,7 +525,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.5 (default, Sep  3 2020, 21:29:08) [MSC v.1916 64 bit (AMD64)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d4a1e18362d261e3cdbeeecc5666b3bbb6e345fd76a9c1e493e1a19dc45aa04d"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/6.MapReduce.ipynb
+++ b/notebooks/6.MapReduce.ipynb
@@ -317,7 +317,7 @@
     "\n",
     "# execute using Hadoop Streaming\n",
     "hadoop jar \\\n",
-    "$HADOOP_HOME/share/hadoop/tools/lib/hadoop-streaming-3.2.2.jar \\\n",
+    "$HADOOP_HOME/share/hadoop/tools/lib/hadoop-streaming-3.2.3.jar \\\n",
     "-input ulysses \\\n",
     "-output ulysses-output \\\n",
     "-mapper wordmapper.py \\\n",


### PR DESCRIPTION
Hadoop 3.2.1 is no longer available in the Apache repository, the next available version is 3.2.3.